### PR TITLE
B Fiks radiogruppe i redigeringskjema

### DIFF
--- a/src/containers/saksopplysning-tabell/RedigeringSkjema.tsx
+++ b/src/containers/saksopplysning-tabell/RedigeringSkjema.tsx
@@ -1,4 +1,4 @@
-import { RadioGroup, Radio, Select, Button, VStack, HStack, Alert } from '@navikt/ds-react';
+import { RadioGroup, Radio, Select, Button, VStack, HStack } from '@navikt/ds-react';
 import { useSWRConfig } from 'swr';
 import toast from 'react-hot-toast';
 import { Controller, FormProvider, useForm } from 'react-hook-form';
@@ -66,7 +66,7 @@ export const RedigeringSkjema = ({
         },
     });
 
-    const håndterHarYtelse = (harYtelseSvar: boolean, onChange: (e: boolean) => void) => {
+    const håndterHarYtelse = (harYtelseSvar: boolean, onChange: (value: boolean) => void) => {
         onChange(harYtelseSvar);
         settHarYtelse(harYtelseSvar);
     };


### PR DESCRIPTION
## Beskrivelse
Redigeringsskjemaet på saksopplysningene fungerer ikke riktig og gir alltid feilmelding dersom man forsøker å sende inn false på `harYtelse`. Ettersom radiogruppen har en defaultverdi og derfor aldri er udefinert fjernet jeg feilhåndteringen på dette spørsmålet. Nå skal det gå fint å sende inn både positiv og negativ verdi for ny saksopplysning.

## Kommentarer
Gjorde også noen bittesmå refaktoreringsting som jeg fikk øye på i farta!