### PR TITLE
R Vis behandlingsperiode i stedet for vilkårsperiode i radio-tekst i …

### DIFF
--- a/src/containers/saksopplysning-tabell/RedigeringSkjema.tsx
+++ b/src/containers/saksopplysning-tabell/RedigeringSkjema.tsx
@@ -117,8 +117,8 @@ export const RedigeringSkjema = ({
                                     <Radio
                                         value={false}
                                     >{`Mottar ikke ${vilkårFlateTittel.toLowerCase()} i perioden ${formatDate(
-                                        vilkårsperiode.fom
-                                    )} til ${formatDate(vilkårsperiode.tom)}`}</Radio>
+                                        behandlingsperiode.fom
+                                    )} til ${formatDate(behandlingsperiode.tom)}`}</Radio>
                                     <Radio value={true}>{`Mottar ${vilkårFlateTittel.toLowerCase()}`}</Radio>
                                 </RadioGroup>
                             );


### PR DESCRIPTION
## Beskrivelse
Bruker behandlingsperiode i stedet for vilkårsperiode i teksten på radiospørsmålet som setter harYtelse til false for hele perioden i redigeringsskjema for saksopplysninger. Dersom SBH legger inn endringer på saksopplysninger der bruker ikke har en ytelse e.l. skal dette settes for hele behandlingsperioden, og det blir derfor feil å bruke vilkårsperioden i teksten.

## Kommentarer
Ordlyden i disse tekstene skal tas opp med pilotbrukerne og det kan bli flere endringer her fremover. Denne endringen legges inn for å gjøre det mindre forvirrende hvilken periode saksopplysningen faktisk settes for når løsningen skal vises frem og diskuteres.

## Visuelle endringer:
<img width="1462" alt="Screenshot 2023-12-14 at 12 22 40" src="https://github.com/navikt/tiltakspenger-saksbehandler/assets/44436236/4f75feee-707c-44da-b530-6ff46c84f0d9">

