### PR TITLE
saksbehandler skal ikke lenger fylle ut navkontor

### DIFF
--- a/src/components/meldekort/meldekortdetaljer/Meldekortdetaljer.tsx
+++ b/src/components/meldekort/meldekortdetaljer/Meldekortdetaljer.tsx
@@ -49,7 +49,7 @@ const Meldekortdetaljer = () => {
             <BodyShort>
               <b>Forrige meldekorts navkontor</b>
             </BodyShort>
-            <BodyShort>{forrigeNavkontor}</BodyShort>
+            <BodyShort>{forrigeNavkontor.kontornummer} {forrigeNavkontor.kontornavn}</BodyShort>
           </>
         )}
         {saksbehandler && (

--- a/src/components/meldekort/meldekortdetaljer/Meldekortdetaljer.tsx
+++ b/src/components/meldekort/meldekortdetaljer/Meldekortdetaljer.tsx
@@ -22,6 +22,7 @@ const Meldekortdetaljer = () => {
     tiltaksnavn,
     vedtaksPeriode,
     forrigeNavkontor,
+    forrigeNavkontorNavn,
     antallDager,
   } = meldekort;
 
@@ -49,7 +50,7 @@ const Meldekortdetaljer = () => {
             <BodyShort>
               <b>Forrige meldekorts navkontor</b>
             </BodyShort>
-            <BodyShort>{forrigeNavkontor.kontornummer} {forrigeNavkontor.kontornavn}</BodyShort>
+            <BodyShort>{forrigeNavkontor} {forrigeNavkontorNavn}</BodyShort>
           </>
         )}
         {saksbehandler && (

--- a/src/components/meldekort/meldekortside/Meldekort.tsx
+++ b/src/components/meldekort/meldekortside/Meldekort.tsx
@@ -29,12 +29,10 @@ import { ukeHeading } from '../../../utils/date';
 import { kanSaksbehandleForBehandling } from '../../../utils/tilganger';
 import { SaksbehandlerContext } from '../../../pages/_app';
 import BekreftelsesModal from '../../bekreftelsesmodal/BekreftelsesModal';
-import { gyldigNavkontor, setupValidation } from '../../../utils/validation';
 
 export interface Meldekortform {
   uke1: MeldekortDagDTO[];
   uke2: MeldekortDagDTO[];
-  navkontor: string;
 }
 
 const Meldekort = () => {
@@ -73,7 +71,6 @@ const Meldekort = () => {
     defaultValues: {
       uke1: meldekortdager.slice(0, 7),
       uke2: meldekortdager.slice(7, 14),
-      navkontor: meldekort.navkontor,
     },
   });
 
@@ -110,25 +107,6 @@ const Meldekort = () => {
             ukeHeading={ukeHeading(meldekort.periode.tilOgMed)}
           />
         </HStack>
-        <Box className={styles.navkontor}>
-          <Controller
-            name="navkontor"
-            control={methods.control}
-            rules={{
-              validate: setupValidation([gyldigNavkontor]),
-            }}
-            render={({ field: { onChange } }) => (
-              <TextField
-                label="Fyll ut navkontor"
-                description="Hvilket navkontor skal utbetale tiltakspenger for bruker på dette meldekortet?"
-                defaultValue={meldekort.navkontor}
-                onChange={onChange}
-                inputMode="numeric"
-                error={methods.formState.errors.navkontor?.message ?? ''}
-              />
-            )}
-          />
-        </Box>
         {kanSaksbehandle && (
           <>
             <Button
@@ -156,7 +134,6 @@ const Meldekort = () => {
                     dager: methods
                       .getValues()
                       .uke1.concat(methods.getValues().uke2),
-                    navkontor: methods.getValues().navkontor,
                   })
                 }
               >

--- a/src/components/meldekort/meldekortside/Meldekortoppsummering.tsx
+++ b/src/components/meldekort/meldekortside/Meldekortoppsummering.tsx
@@ -74,7 +74,7 @@ const Meldekortoppsummering = () => {
         <BodyShort weight="semibold">
           Navkontor det skal utbetales fra:
         </BodyShort>
-        <BodyShort weight="semibold">{meldekort.navkontor}</BodyShort>
+        <BodyShort weight="semibold">{meldekort.navkontor.kontornummer} {meldekort.navkontor.kontornavn}</BodyShort>
       </HStack>
       {kanBeslutte && (
         <>

--- a/src/components/meldekort/meldekortside/Meldekortoppsummering.tsx
+++ b/src/components/meldekort/meldekortside/Meldekortoppsummering.tsx
@@ -74,7 +74,7 @@ const Meldekortoppsummering = () => {
         <BodyShort weight="semibold">
           Navkontor det skal utbetales fra:
         </BodyShort>
-        <BodyShort weight="semibold">{meldekort.navkontor.kontornummer} {meldekort.navkontor.kontornavn}</BodyShort>
+        <BodyShort weight="semibold">{meldekort.navkontor} {meldekort.navkontorNavn}</BodyShort>
       </HStack>
       {kanBeslutte && (
         <>

--- a/src/types/MeldekortTypes.ts
+++ b/src/types/MeldekortTypes.ts
@@ -20,8 +20,10 @@ export type Meldekort = {
   totalbeløpTilUtbetaling: number;
   vedtaksPeriode: Periode;
   antallDager: number;
-  navkontor?: Navkontor;
-  forrigeNavkontor?: Navkontor;
+  navkontor?: string;
+  navkontorNavn?: string,
+  forrigeNavkontor?: string,
+  forrigeNavkontorNavn?: string;
 };
 
 export enum Meldekortstatus {
@@ -29,11 +31,6 @@ export enum Meldekortstatus {
   KLAR_TIL_UTFYLLING = 'KLAR_TIL_UTFYLLING',
   KLAR_TIL_BESLUTNING = 'KLAR_TIL_BESLUTNING',
   GODKJENT = 'GODKJENT',
-}
-
-export type Navkontor = {
-  kontornummer: string,
-  kontornavn?: string,
 }
 
 export type MeldekortDag = {

--- a/src/types/MeldekortTypes.ts
+++ b/src/types/MeldekortTypes.ts
@@ -20,8 +20,8 @@ export type Meldekort = {
   totalbeløpTilUtbetaling: number;
   vedtaksPeriode: Periode;
   antallDager: number;
-  navkontor?: string;
-  forrigeNavkontor?: string;
+  navkontor?: Navkontor;
+  forrigeNavkontor?: Navkontor;
 };
 
 export enum Meldekortstatus {
@@ -29,6 +29,11 @@ export enum Meldekortstatus {
   KLAR_TIL_UTFYLLING = 'KLAR_TIL_UTFYLLING',
   KLAR_TIL_BESLUTNING = 'KLAR_TIL_BESLUTNING',
   GODKJENT = 'GODKJENT',
+}
+
+export type Navkontor = {
+  kontornummer: string,
+  kontornavn?: string,
 }
 
 export type MeldekortDag = {
@@ -82,7 +87,6 @@ export enum Tiltakstype {
 
 export type MeldekortDTO = {
   dager: MeldekortDagDTO[];
-  navkontor: string;
 };
 
 export enum MeldekortdagStatus {

--- a/src/utils/feilmeldinger.ts
+++ b/src/utils/feilmeldinger.ts
@@ -12,8 +12,6 @@ export const finnFeilmelding = (errorkode: string) => {
       return 'Beslutterrolle mangler for innlogget saksbehandler';
     case 'beslutter_og_saksbehandler_kan_ikke_være_lik':
       'Saksbehandler og beslutter kan ikke være samme person';
-    case 'ugyldig_kontornummer':
-      return 'Navkontoret forventes å være fire siffer';
     case 'må_være_beslutter_eller_saksbehandler':
       return 'Ingen tilgang. Har ikke påkrevd rolle for å kunne gjennomføre handlingen';
     case 'må_ha_beslutter_rolle':

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -10,16 +10,6 @@ export function påkrevdPeriodeValidator(periode: { fra: Date; til: Date }) {
   }
 }
 
-export function gyldigNavkontor(navkontor: string) {
-  if (!navkontor) {
-    return 'Navkontor må fylles ut';
-  } else if (navkontor.length != 4) {
-    return 'Navkontor må inneholde nøyaktig fire siffer';
-  } else if (!inneholderKunTall(navkontor)) {
-    return 'Navkontor kan kun inneholde siffer';
-  }
-}
-
 export function gyldigPeriodeValidator(periode: { fra: Date; til: Date }) {
   const fraDato = dayjs(periode?.fra);
   const tilDato = dayjs(periode?.til);


### PR DESCRIPTION
## Beskrivelse
Navkontor for meldekort skal hentes fra veilarboppfølging så saksbehandler skal slippe å fylle det ut manuelt. Vi skal også vise navn på navkontor i tillegg til nummer hvis det finnes. 

## Kommentarer
(https://trello.com/c/uiiwH7uw/1147-sl%C3%A5-opp-navkontor-saksbehandler-legger-inn-mot-norg-og-vise-navnet)

Backend: https://github.com/navikt/tiltakspenger-saksbehandling-api/pull/775

## Visuelle endringer:
Har ingen skisser, så er åpen for at det kanskje bør se annerledes ut 😅 