### PR TITLE
prøver å vise datoer hvis flere deltakelser har samme tiltakstype

### DIFF
--- a/src/components/behandling/førstegangsbehandling/3-tiltak/perioder/TiltakPerioder.tsx
+++ b/src/components/behandling/førstegangsbehandling/3-tiltak/perioder/TiltakPerioder.tsx
@@ -8,7 +8,7 @@ import {
 import { hentTiltaksdeltakelserMedStartOgSluttdato } from '../../../../../utils/behandling';
 import { VedtakTiltaksdeltakelsePeriode } from '../../../../../types/VedtakTyper';
 import { SaksbehandlerRolle } from '../../../../../types/Saksbehandler';
-import { dateTilISOTekst } from '../../../../../utils/date';
+import { dateTilISOTekst, periodeTilFormatertDatotekst } from '../../../../../utils/date';
 import { useFørstegangsbehandling } from '../../../BehandlingContext';
 
 import style from './TiltakPerioder.module.css';
@@ -96,7 +96,7 @@ const TiltakPeriode = ({
                         value={tiltak.eksternDeltagelseId}
                         key={`${tiltak.deltagelseFraOgMed}-${tiltak.eksternDeltagelseId}-${index}`}
                     >
-                        {tiltak.typeNavn}
+                        {getVisningsnavn(tiltak, tiltaksdeltakelser)}
                     </option>
                 ))}
             </Select>
@@ -161,4 +161,21 @@ const TiltakPeriode = ({
             )}
         </div>
     );
+};
+
+const getVisningsnavn = (
+    tiltaksdeltagelse: Tiltaksdeltagelse,
+    tiltaksdeltakelser: Tiltaksdeltagelse[],
+): string => {
+    const deltakelserMedType = tiltaksdeltakelser.filter(
+        (t) => t.typeKode === tiltaksdeltagelse.typeKode,
+    );
+    if (deltakelserMedType.length > 1) {
+        return `${tiltaksdeltagelse.typeNavn} (${periodeTilFormatertDatotekst({
+            fraOgMed: tiltaksdeltagelse.deltagelseFraOgMed!,
+            tilOgMed: tiltaksdeltagelse.deltagelseTilOgMed!,
+        })})`;
+    } else {
+        return tiltaksdeltagelse.typeNavn;
+    }
 };


### PR DESCRIPTION
## Beskrivelse
Ideelt sett burde ikke saksbehandler måtte velge mellom like tiltakstyper, men det er ikke så lett å få til. For å sminke grisen litt viser vi deltakelsesperioden hvis det er mer enn en deltakelse for en tiltakstype slik at det blir lettere å forstå hva man velger. 

## Kommentarer
https://trello.com/c/1i0Re1hA/1394-forbedring-saksbehandler-skal-ikke-m%C3%A5tte-velge-tiltaksperioder-ved-overlappende-deltakelser-p%C3%A5-samme-tiltakstype

## Visuelle endringer:
<!--- Legg ved skjermbilder av de visuelle endringene dersom det er relevant -->
