### PR TITLE
1398 begrunnelse for meldekort

### DIFF
--- a/src/components/meldekort/meldekortside/Meldekort.module.css
+++ b/src/components/meldekort/meldekortside/Meldekort.module.css
@@ -29,6 +29,13 @@
     }
 }
 
+.begrunnelse {
+    background-color: #ffffff;
+    border: 1px #9099a5 solid;
+    border-radius: 4px;
+    padding: 0.5rem;
+}
+
 .meldekort {
     background-color: #ffffff;
     border: 1px #9099a5 solid;
@@ -47,4 +54,8 @@
     border: 1px #9099a5 solid;
     border-radius: 4px;
     padding: 1rem;
+}
+
+.personinfoVarsel {
+    font-style: italic;
 }

--- a/src/components/meldekort/meldekortside/meldekort-behandling/MeldekortBehandlingOppsummering.tsx
+++ b/src/components/meldekort/meldekortside/meldekort-behandling/MeldekortBehandlingOppsummering.tsx
@@ -1,4 +1,4 @@
-import { HStack, BodyShort, Button, VStack } from '@navikt/ds-react';
+import { HStack, BodyShort, Button, VStack, Heading, Textarea } from '@navikt/ds-react';
 import { ukeHeading } from '../../../../utils/date';
 import { Utbetalingsuke } from '../Utbetalingsuke';
 import { useRef } from 'react';
@@ -49,6 +49,23 @@ export const MeldekortBehandlingOppsummering = ({ meldeperiode }: Props) => {
                 utbetalingUke={uke2}
                 headingtekst={ukeHeading(meldeperiode.periode.tilOgMed)}
             />
+            {meldekortBehandling.begrunnelse && (
+                <VStack className={styles.begrunnelse}>
+                    <>
+                        <Heading size={'xsmall'} level={'2'} className={styles.header}>
+                            {'Begrunnelse (valgfri)'}
+                        </Heading>
+                        <Textarea
+                            label={'Begrunnelse'}
+                            hideLabel={true}
+                            minRows={5}
+                            resize={'vertical'}
+                            readOnly={true}
+                            defaultValue={meldekortBehandling.begrunnelse}
+                        />
+                    </>
+                </VStack>
+            )}
             <VStack>
                 <HStack gap="5" className={styles.totalbeløp}>
                     <BodyShort weight="semibold">Totalt ordinær beløp for perioden:</BodyShort>

--- a/src/components/meldekort/meldekortside/meldekort-behandling/behandling/MeldekortBehandling.tsx
+++ b/src/components/meldekort/meldekortside/meldekort-behandling/behandling/MeldekortBehandling.tsx
@@ -1,4 +1,13 @@
-import { Alert, BodyShort, Button, HStack, Spacer } from '@navikt/ds-react';
+import {
+    Alert,
+    BodyLong,
+    BodyShort,
+    Button,
+    Heading,
+    HStack,
+    Spacer,
+    Textarea,
+} from '@navikt/ds-react';
 import { useRef, useState } from 'react';
 import { useSak } from '../../../../../context/sak/SakContext';
 import { useSendMeldekortTilBeslutter } from '../../../hooks/useSendMeldekortTilBeslutter';
@@ -36,6 +45,7 @@ export const MeldekortBehandling = ({ meldeperiode }: Props) => {
         defaultValues: {
             uke1: dagerDefault.slice(0, 7),
             uke2: dagerDefault.slice(7, 14),
+            begrunnelse: undefined,
         },
     });
 
@@ -77,6 +87,21 @@ export const MeldekortBehandling = ({ meldeperiode }: Props) => {
                     <Spacer />
                     <MeldekortBehandlingUke dager={formMethods.getValues().uke2} ukenummer={2} />
                 </HStack>
+                <Heading size={'xsmall'} level={'2'} className={styles.header}>
+                    {'Begrunnelse (valgfri)'}
+                </Heading>
+                <BodyLong size={'small'} className={styles.personinfoVarsel}>
+                    {'Ikke skriv personsensitiv informasjon som ikke er relevant for saken.'}
+                </BodyLong>
+                <Textarea
+                    label={'Begrunnelse'}
+                    hideLabel={true}
+                    minRows={5}
+                    resize={'vertical'}
+                    onChange={(event) => {
+                        formMethods.setValue('begrunnelse', event.target.value);
+                    }}
+                />
                 {valideringsFeil && (
                     <Alert variant={'error'}>
                         <BodyShort weight={'semibold'}>{'Feil i utfyllingen'}</BodyShort>
@@ -100,6 +125,7 @@ export const MeldekortBehandling = ({ meldeperiode }: Props) => {
                                     dager: formMethods
                                         .getValues()
                                         .uke1.concat(formMethods.getValues().uke2),
+                                    begrunnelse: formMethods.getValues().begrunnelse,
                                 }).then((meldekortBehandling) => {
                                     if (meldekortBehandling) {
                                         setMeldekortbehandling(

--- a/src/components/meldekort/meldekortside/meldekort-behandling/behandling/meldekortBehandlingUtils.ts
+++ b/src/components/meldekort/meldekortside/meldekort-behandling/behandling/meldekortBehandlingUtils.ts
@@ -59,4 +59,5 @@ const dagerMedDeltattEllerFravær: ReadonlySet<MeldekortBehandlingDagStatus> = n
 export type MeldekortBehandlingForm = {
     uke1: MeldekortBehandlingDagProps[];
     uke2: MeldekortBehandlingDagProps[];
+    begrunnelse?: string;
 };

--- a/src/types/meldekort/MeldekortBehandling.ts
+++ b/src/types/meldekort/MeldekortBehandling.ts
@@ -40,6 +40,7 @@ export type MeldekortBehandlingProps = {
     navkontor: string;
     navkontorNavn?: string;
     dager: MeldekortBehandlingDagBeregnet[];
+    begrunnelse?: string;
 };
 
 export type MeldekortBehandlingDagProps = {
@@ -60,4 +61,5 @@ type Beregningsdag = {
 
 export type MeldekortBehandlingDTO = {
     dager: MeldekortBehandlingDagProps[];
+    begrunnelse?: string;
 };

--- a/src/types/meldekort/Meldeperiode.ts
+++ b/src/types/meldekort/Meldeperiode.ts
@@ -35,6 +35,7 @@ export type MeldeperiodeKjedeProps = {
     periode: Periode;
     tiltaksnavn?: string[];
     meldeperioder: MeldeperiodeProps[];
+    begrunnelse?: string;
 };
 
 export type MeldeperiodeMedBehandlingProps = MeldeperiodeProps &


### PR DESCRIPTION
## Beskrivelse
Saksbehandler skal kunne legge inn begrunnelse for meldekort

## Kommentarer
https://trello.com/c/xKq1PSBo/1398-meldekortbehandling-legg-til-begrunnelsesfelt-som-vises-i-oppsummering-og-til-beslutter

## Visuelle endringer:
<!--- Legg ved skjermbilder av de visuelle endringene dersom det er relevant -->
