### PR TITLE
1400 legger til informasjon om hvorfor saksbehandler må velge tiltak

### DIFF
--- a/src/components/behandling/førstegangsbehandling/3-tiltak/FørstegangsVedtakTiltak.tsx
+++ b/src/components/behandling/førstegangsbehandling/3-tiltak/FørstegangsVedtakTiltak.tsx
@@ -20,7 +20,8 @@ export const FørstegangsVedtakTiltak = () => {
                     <VedtakSeksjon.Venstre>
                         <Alert variant={'warning'} size={'small'}>
                             Flere tiltak registrert på bruker. Velg tiltak(ene) som bruker skal
-                            vurderes for og periodene som gjelder.
+                            vurderes for og periodene som gjelder. Det du velger brukes for
+                            regnskapsføring og statistikk, og påvirker ikke vedtaket.
                         </Alert>
                     </VedtakSeksjon.Venstre>
                 </VedtakSeksjon>


### PR DESCRIPTION
## Beskrivelse
Forsøk på å beskrive hvorfor saksbehandler må velge blant flere tiltak og hva det brukes for. 

## Kommentarer
https://trello.com/c/rOTrIKah/1400-informere-saksbehandler-om-hvorfor-de-m%C3%A5-velge-tiltak-og-perioder-for-tiltakene

## Visuelle endringer:
<!--- Legg ved skjermbilder av de visuelle endringene dersom det er relevant -->
