### PR TITLE
1458 saksbehandler skal kunne overta meldekortbehandling

### DIFF
--- a/src/components/saksoversikt/Saksoversikt.tsx
+++ b/src/components/saksoversikt/Saksoversikt.tsx
@@ -64,6 +64,7 @@ export const Saksoversikt = () => {
                         <MeldekortOversikt
                             meldeperiodeKjeder={meldeperiodeKjederKlare}
                             saksnummer={saksnummer}
+                            sakId={sakId}
                         />
                     )}
                 </Box>

--- a/src/components/saksoversikt/meldekort-oversikt/MeldekortBehandlingKnappForOversikt.tsx
+++ b/src/components/saksoversikt/meldekort-oversikt/MeldekortBehandlingKnappForOversikt.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { Button, VStack } from '@navikt/ds-react';
+import Link from 'next/link';
+
+import style from './MeldekortBehandlingKnapper.module.css';
+import {
+    MeldekortBehandlingProps,
+    MeldekortBehandlingStatus,
+} from '../../../types/meldekort/MeldekortBehandling';
+import { eierMeldekortBehandling } from '../../../utils/tilganger';
+import { useSaksbehandler } from '../../../context/saksbehandler/SaksbehandlerContext';
+import OvertaMeldekortBehandling from './OvertaMeldekortBehandling';
+import { SakId } from '../../../types/SakTypes';
+
+type Props = {
+    meldekortBehandling: MeldekortBehandlingProps;
+    sakId: SakId;
+    meldeperiodeUrl: string;
+};
+
+export const MeldekortBehandlingKnappForOversikt = ({
+    meldekortBehandling,
+    sakId,
+    meldeperiodeUrl,
+}: Props) => {
+    const { status, id } = meldekortBehandling;
+
+    const { innloggetSaksbehandler } = useSaksbehandler();
+
+    switch (status) {
+        case MeldekortBehandlingStatus.KLAR_TIL_UTFYLLING:
+            if (!eierMeldekortBehandling(meldekortBehandling, innloggetSaksbehandler)) {
+                if (
+                    innloggetSaksbehandler.navIdent === meldekortBehandling.saksbehandler ||
+                    innloggetSaksbehandler.navIdent === meldekortBehandling.beslutter
+                ) {
+                    return null;
+                }
+
+                return (
+                    <OvertaMeldekortBehandling
+                        sakId={sakId}
+                        meldekortBehandlingId={id}
+                        overtarFra={
+                            meldekortBehandling.status ===
+                            MeldekortBehandlingStatus.KLAR_TIL_UTFYLLING
+                                ? meldekortBehandling.saksbehandler!
+                                : 'Ukjent saksbehandler/beslutter'
+                        }
+                        meldeperiodeUrl={meldeperiodeUrl}
+                    />
+                );
+            }
+
+            return (
+                <VStack align="start" gap="2">
+                    <Button
+                        className={style.knapp}
+                        size="small"
+                        variant="secondary"
+                        as={Link}
+                        href={meldeperiodeUrl}
+                    >
+                        Fortsett
+                    </Button>
+                </VStack>
+            );
+    }
+
+    return null;
+};

--- a/src/components/saksoversikt/meldekort-oversikt/MeldekortBehandlingKnapper.module.css
+++ b/src/components/saksoversikt/meldekort-oversikt/MeldekortBehandlingKnapper.module.css
@@ -1,0 +1,11 @@
+.knapp {
+    min-width: 50%;
+}
+
+.varsel {
+    margin-bottom: 0.25rem;
+}
+
+.knappV2 {
+    margin-top: 0.25rem;
+}

--- a/src/components/saksoversikt/meldekort-oversikt/MeldekortOversikt.tsx
+++ b/src/components/saksoversikt/meldekort-oversikt/MeldekortOversikt.tsx
@@ -15,13 +15,16 @@ import { formatterBeløp } from '../../../utils/beløp';
 import { sorterMeldekortBehandlingerAsc } from '../../../utils/meldekort';
 
 import style from './MeldekortOversikt.module.css';
+import { MeldekortBehandlingKnappForOversikt } from './MeldekortBehandlingKnappForOversikt';
+import { SakId } from '../../../types/SakTypes';
 
 type Props = {
     meldeperiodeKjeder: MeldeperiodeKjedeProps[];
     saksnummer: string;
+    sakId: SakId;
 };
 
-export const MeldekortOversikt = ({ meldeperiodeKjeder, saksnummer }: Props) => {
+export const MeldekortOversikt = ({ meldeperiodeKjeder, saksnummer, sakId }: Props) => {
     return (
         <Table>
             <Table.Header>
@@ -33,6 +36,7 @@ export const MeldekortOversikt = ({ meldeperiodeKjeder, saksnummer }: Props) => 
                     <Table.HeaderCell scope="col">Mottatt fra bruker</Table.HeaderCell>
                     <Table.HeaderCell scope="col">Saksbehandler</Table.HeaderCell>
                     <Table.HeaderCell scope="col">Beslutter</Table.HeaderCell>
+                    <Table.HeaderCell scope="col">Handlinger</Table.HeaderCell>
                     <Table.HeaderCell scope="col"></Table.HeaderCell>
                 </Table.Row>
             </Table.Header>
@@ -97,6 +101,15 @@ export const MeldekortOversikt = ({ meldeperiodeKjeder, saksnummer }: Props) => 
                                 </Table.DataCell>
                                 <Table.DataCell>
                                     {sisteMeldekortBehandling?.beslutter ?? '-'}
+                                </Table.DataCell>
+                                <Table.DataCell scope="col">
+                                    {sisteMeldekortBehandling && (
+                                        <MeldekortBehandlingKnappForOversikt
+                                            meldekortBehandling={sisteMeldekortBehandling}
+                                            sakId={sakId}
+                                            meldeperiodeUrl={meldeperiodeUrl(saksnummer, periode)}
+                                        />
+                                    )}
                                 </Table.DataCell>
                                 <Table.DataCell>
                                     <Button

--- a/src/components/saksoversikt/meldekort-oversikt/OvertaMeldekortBehandling.tsx
+++ b/src/components/saksoversikt/meldekort-oversikt/OvertaMeldekortBehandling.tsx
@@ -1,0 +1,105 @@
+import { Alert, BodyShort, Button, Heading, HStack, Modal, VStack } from '@navikt/ds-react';
+import { useState } from 'react';
+import router from 'next/router';
+
+import style from './MeldekortBehandlingKnapper.module.css';
+import {
+    MeldekortBehandlingId,
+    MeldekortBehandlingProps,
+} from '../../../types/meldekort/MeldekortBehandling';
+import { useFetchJsonFraApi } from '../../../utils/fetch/useFetchFraApi';
+import { SakId } from '../../../types/SakTypes';
+
+const OvertaMeldekortbehandlingModal = (props: {
+    sakId: SakId;
+    meldekortBehandlingId: MeldekortBehandlingId;
+    overtarFra: string;
+    meldeperiodeUrl: string;
+    åpen: boolean;
+    onClose: () => void;
+}) => {
+    const overtaMeldekortBehandlingApi = useFetchJsonFraApi<
+        MeldekortBehandlingProps,
+        { overtarFra: string }
+    >(`/sak/${props.sakId}/meldekort/${props.meldekortBehandlingId}/overta`, 'PATCH', {
+        onSuccess: () => {
+            router.push(props.meldeperiodeUrl);
+        },
+    });
+
+    return (
+        <Modal width={480} aria-label="Overta behandling" open={props.åpen} onClose={props.onClose}>
+            <Modal.Header>
+                <Heading size="medium" level="3">
+                    Overta meldekortbehandling
+                </Heading>
+            </Modal.Header>
+            <Modal.Body>
+                <BodyShort>
+                    Er du sikker på at du vil ta over meldekortbehandlingen fra {props.overtarFra}?
+                </BodyShort>
+            </Modal.Body>
+            <Modal.Footer>
+                <VStack gap="4">
+                    {overtaMeldekortBehandlingApi.error && (
+                        <Alert variant={'error'}>
+                            {overtaMeldekortBehandlingApi.error.message}
+                        </Alert>
+                    )}
+                    <HStack gap="2">
+                        <Button type="button" variant="secondary" onClick={props.onClose}>
+                            Avbryt
+                        </Button>
+                        <Button
+                            type="button"
+                            onClick={() =>
+                                overtaMeldekortBehandlingApi.trigger({
+                                    overtarFra: props.overtarFra,
+                                })
+                            }
+                            loading={overtaMeldekortBehandlingApi.isMutating}
+                        >
+                            Overta behandling
+                        </Button>
+                    </HStack>
+                </VStack>
+            </Modal.Footer>
+        </Modal>
+    );
+};
+
+const OvertaMeldekortBehandling = (props: {
+    sakId: SakId;
+    meldekortBehandlingId: MeldekortBehandlingId;
+    overtarFra: string;
+    meldeperiodeUrl: string;
+}) => {
+    const [vilOvertaBehandling, setVilOvertaBehandling] = useState(false);
+
+    return (
+        <div>
+            {vilOvertaBehandling && (
+                <OvertaMeldekortbehandlingModal
+                    åpen={vilOvertaBehandling}
+                    onClose={() => setVilOvertaBehandling(false)}
+                    sakId={props.sakId}
+                    meldekortBehandlingId={props.meldekortBehandlingId}
+                    overtarFra={props.overtarFra}
+                    meldeperiodeUrl={props.meldeperiodeUrl}
+                />
+            )}
+            <Button
+                className={style.knapp}
+                size="small"
+                variant="secondary"
+                onClick={() => {
+                    setVilOvertaBehandling(true);
+                }}
+            >
+                Overta behandling
+            </Button>
+        </div>
+    );
+};
+
+export default OvertaMeldekortBehandling;

--- a/src/utils/tilganger.ts
+++ b/src/utils/tilganger.ts
@@ -82,6 +82,20 @@ export const kanBeslutteForMeldekort = (
     );
 };
 
+export const eierMeldekortBehandling = (
+    meldekortBehandling: MeldekortBehandlingProps,
+    innloggetSaksbehandler: Saksbehandler,
+): boolean => {
+    const { status, saksbehandler } = meldekortBehandling;
+
+    switch (status) {
+        case MeldekortBehandlingStatus.KLAR_TIL_UTFYLLING:
+            return innloggetSaksbehandler.navIdent === saksbehandler;
+        default:
+            return false;
+    }
+};
+
 export const skalKunneTaBehandling = (
     behandling: BehandlingForOversiktData,
     innloggetSaksbehandler: Saksbehandler,


### PR DESCRIPTION
Gir saksbehandler mulighet til å ta over en meldekortbehandling fra en annen saksbehandler. Når saksbehandler eier meldekortbehandlingen selv vises en "Fortsett"-knapp i saksoversikten, mens hvis en annen saksbehandler eier behandlingen vises en "overta behandling"-knapp, altså tilsvarende som for søknadsbehandlingen. 

Vi har også en Åpne-knapp som vises nå. Jeg tenkte å rydde litt i når den vises når vi får på plass tildel-funksjonalitet for beslutter, og kanskje endre navn til "Se behandling" så det blir likt som for søknaden. 

https://trello.com/c/iYXkiirR/1458-en-p%C3%A5startet-manuell-meldekortbehandling-m%C3%A5-kunne-overtas-av-en-annen-saksbehandler