### PR TITLE
1468 saksbehandler/beslutter kan legge tilbake behandling

### DIFF
--- a/src/components/behandlingsknapper/BehandlingKnappForOversikt.tsx
+++ b/src/components/behandlingsknapper/BehandlingKnappForOversikt.tsx
@@ -14,6 +14,7 @@ import router from 'next/router';
 
 import style from './BehandlingKnapper.module.css';
 import OvertaBehandling from './OvertaBehandling';
+import { useLeggTilbakeBehandling } from './useLeggTilbakeBehandling';
 
 type Props = {
     behandling: BehandlingForOversiktData;
@@ -25,6 +26,10 @@ export const BehandlingKnappForOversikt = ({ behandling, medAvsluttBehandling }:
 
     const { innloggetSaksbehandler } = useSaksbehandler();
     const { taBehandling, isBehandlingMutating } = useTaBehandling(sakId, id);
+    const { leggTilbakeBehandling, isLeggTilbakeBehandlingMutating } = useLeggTilbakeBehandling(
+        sakId,
+        id,
+    );
 
     const behandlingLenke = `/behandling/${id}`;
 
@@ -59,11 +64,26 @@ export const BehandlingKnappForOversikt = ({ behandling, medAvsluttBehandling }:
                     <Button
                         className={style.knapp}
                         size="small"
-                        variant="secondary"
+                        variant="primary"
                         as={Link}
                         href={behandlingLenke}
                     >
                         Fortsett
+                    </Button>
+                    <Button
+                        className={style.knapp}
+                        size={'small'}
+                        variant={'secondary'}
+                        loading={isLeggTilbakeBehandlingMutating}
+                        as={'a'}
+                        onClick={(e) => {
+                            e.preventDefault();
+                            leggTilbakeBehandling().then(() => {
+                                router.push(`/sak/${behandling.saksnummer}`);
+                            });
+                        }}
+                    >
+                        {'Legg tilbake'}
                     </Button>
                     {medAvsluttBehandling && status === BehandlingStatus.UNDER_BEHANDLING && (
                         <AvsluttBehandling

--- a/src/components/behandlingsknapper/useLeggTilbakeBehandling.ts
+++ b/src/components/behandlingsknapper/useLeggTilbakeBehandling.ts
@@ -1,0 +1,16 @@
+import { BehandlingData, BehandlingId } from '../../types/BehandlingTypes';
+import { SakId } from '../../types/SakTypes';
+import { useFetchJsonFraApi } from '../../utils/fetch/useFetchFraApi';
+
+export const useLeggTilbakeBehandling = (sakId: SakId, behandlingId: BehandlingId) => {
+    const {
+        trigger: leggTilbakeBehandling,
+        isMutating: isLeggTilbakeBehandlingMutating,
+        error: leggTilbakeBehandlingError,
+    } = useFetchJsonFraApi<BehandlingData>(
+        `/sak/${sakId}/behandling/${behandlingId}/legg-tilbake`,
+        'POST',
+    );
+
+    return { leggTilbakeBehandling, isLeggTilbakeBehandlingMutating, leggTilbakeBehandlingError };
+};


### PR DESCRIPTION
Legger til knapp for at saksbehandler/beslutter skal kunne legge behandlingen tilbake (fjerne seg selv fra behandlingen). Har også gjort "Fortsett"-knappen til primary slik at vi tydeliggjør at den er førstevalget nå som det begynner å bli flere knapper. 

https://trello.com/c/gMr9XKsr/1468-legg-tilbake-behandling-saksbehandler-og-beslutter-meldekort-og-s%C3%B8knadsbehandling