### PR TITLE
1461 skal kunne avslutte meldekortbehandling

### DIFF
--- a/src/components/meldekort/1-venstre-seksjon/MeldekortVenstreSeksjon.tsx
+++ b/src/components/meldekort/1-venstre-seksjon/MeldekortVenstreSeksjon.tsx
@@ -138,6 +138,7 @@ const meldekortStatusTagVariant: Record<
     KLAR_TIL_BESLUTNING: 'alt1-moderate',
     UNDER_BEHANDLING: 'alt3-moderate',
     UNDER_BESLUTNING: 'alt3-moderate',
+    AVBRUTT: 'warning-moderate',
 };
 
 const meldekortStatusIkon: Record<MeldeperiodeKjedeStatus, React.ReactNode> = {
@@ -149,4 +150,5 @@ const meldekortStatusIkon: Record<MeldeperiodeKjedeStatus, React.ReactNode> = {
     [MeldeperiodeKjedeStatus.UNDER_BESLUTNING]: <NotePencilIcon />,
     [MeldeperiodeKjedeStatus.GODKJENT]: <CheckmarkIcon />,
     [MeldeperiodeKjedeStatus.AUTOMATISK_BEHANDLET]: <RobotSmileIcon />,
+    [MeldeperiodeKjedeStatus.AVBRUTT]: <CircleSlashIcon />,
 };

--- a/src/components/meldekort/3-høyre-seksjon/MeldekortHøyreSeksjon.tsx
+++ b/src/components/meldekort/3-høyre-seksjon/MeldekortHøyreSeksjon.tsx
@@ -3,9 +3,10 @@ import { MeldekortTidligereBehandlinger } from './tidligere-behandlinger/Meldeko
 import { BrukersMeldekortVisning } from './brukers-meldekort/BrukersMeldekort';
 import { useMeldeperiodeKjede } from '../MeldeperiodeKjedeContext';
 import { classNames } from '../../../utils/classNames';
-import { DocPencilIcon, PersonPencilIcon } from '@navikt/aksel-icons';
+import { CircleSlashIcon, DocPencilIcon, PersonPencilIcon } from '@navikt/aksel-icons';
 
 import style from './MeldekortHøyreSeksjon.module.css';
+import { MeldekortAvsluttedeBehandlinger } from './avsluttede-meldekort/MeldekortAvsluttedeBehandlinger';
 
 export const MeldekortHøyreSeksjon = () => {
     const {
@@ -13,6 +14,7 @@ export const MeldekortHøyreSeksjon = () => {
         tidligereMeldekortBehandlinger,
         meldeperiodeKjede,
         sisteMeldeperiode,
+        avbrutteMeldekortBehandlinger,
     } = useMeldeperiodeKjede();
 
     const { brukersMeldekort, korrigeringFraTidligerePeriode } = meldeperiodeKjede;
@@ -22,6 +24,8 @@ export const MeldekortHøyreSeksjon = () => {
         : tidligereMeldekortBehandlinger.length;
 
     const antallBrukersMeldekort = brukersMeldekort ? 1 : 0;
+
+    const antallAvbrutteMeldekortBehandlinger = avbrutteMeldekortBehandlinger.length;
 
     const defaultTab =
         antallBrukersMeldekort > 0 && antallTidligereBehandlinger === 0
@@ -43,6 +47,14 @@ export const MeldekortHøyreSeksjon = () => {
                     icon={<PersonPencilIcon />}
                     className={classNames(antallBrukersMeldekort === 0 && style.tabDisabled)}
                 />
+                <Tabs.Tab
+                    value={'avsluttedeMeldekort'}
+                    label={'Avsluttede behandlinger'}
+                    icon={<CircleSlashIcon />}
+                    className={classNames(
+                        antallAvbrutteMeldekortBehandlinger === 0 && style.tabDisabled,
+                    )}
+                />
             </Tabs.List>
 
             <Tabs.Panel value={'tidligereBehandlinger'} lazy={false} className={style.panel}>
@@ -56,6 +68,10 @@ export const MeldekortHøyreSeksjon = () => {
                         brukersMeldekort={brukersMeldekort}
                     />
                 )}
+            </Tabs.Panel>
+
+            <Tabs.Panel value={'avsluttedeMeldekort'} lazy={false} className={style.panel}>
+                {antallAvbrutteMeldekortBehandlinger > 0 && <MeldekortAvsluttedeBehandlinger />}
             </Tabs.Panel>
         </Tabs>
     );

--- a/src/components/meldekort/3-høyre-seksjon/avsluttede-meldekort/AvsluttetMeldekortOppsummering.tsx
+++ b/src/components/meldekort/3-høyre-seksjon/avsluttede-meldekort/AvsluttetMeldekortOppsummering.tsx
@@ -1,0 +1,43 @@
+import { HStack, VStack } from '@navikt/ds-react';
+import { formaterTidspunkt } from '../../../../utils/date';
+import { MeldekortBehandlingProps } from '../../../../types/meldekort/MeldekortBehandling';
+import { MeldekortUker } from '../../0-felles-komponenter/uker/MeldekortUker';
+import { MeldekortBeregningOppsummering } from '../../0-felles-komponenter/beregning-oppsummering/MeldekortBeregningOppsummering';
+import { MeldekortBegrunnelse } from '../../0-felles-komponenter/begrunnelse/MeldekortBegrunnelse';
+import { OppsummeringsPar } from '../../../oppsummeringer/oppsummeringspar/OppsummeringsPar';
+import React from 'react';
+
+type Props = {
+    meldekortBehandling: MeldekortBehandlingProps;
+};
+
+export const AvsluttetMeldekortOppsummering = ({ meldekortBehandling }: Props) => {
+    const { beregning, begrunnelse, dager, avbrutt } = meldekortBehandling;
+
+    return (
+        avbrutt && (
+            <VStack gap={'5'}>
+                <HStack gap="6">
+                    <OppsummeringsPar
+                        label={'Avsluttet av'}
+                        verdi={avbrutt.avbruttAv}
+                        retning="vertikal"
+                    />
+                    <OppsummeringsPar
+                        label={'Tidspunkt avsluttet'}
+                        verdi={formaterTidspunkt(avbrutt.avbruttTidspunkt)}
+                        retning="vertikal"
+                    />
+                </HStack>
+                <OppsummeringsPar
+                    label={'Begrunnelse'}
+                    verdi={avbrutt.begrunnelse}
+                    retning="vertikal"
+                />
+                <MeldekortUker dager={beregning?.beregningForMeldekortetsPeriode.dager ?? dager} />
+                <MeldekortBeregningOppsummering meldekortBehandling={meldekortBehandling} />
+                {begrunnelse && <MeldekortBegrunnelse readOnly={true} defaultValue={begrunnelse} />}
+            </VStack>
+        )
+    );
+};

--- a/src/components/meldekort/3-høyre-seksjon/avsluttede-meldekort/MeldekortAvsluttedeBehandlinger.module.css
+++ b/src/components/meldekort/3-høyre-seksjon/avsluttede-meldekort/MeldekortAvsluttedeBehandlinger.module.css
@@ -1,0 +1,4 @@
+.toppRad {
+    display: flex;
+    justify-content: space-between;
+}

--- a/src/components/meldekort/3-høyre-seksjon/avsluttede-meldekort/MeldekortAvsluttedeBehandlinger.tsx
+++ b/src/components/meldekort/3-høyre-seksjon/avsluttede-meldekort/MeldekortAvsluttedeBehandlinger.tsx
@@ -1,0 +1,65 @@
+import { HStack, Select, VStack } from '@navikt/ds-react';
+import { MeldekortBehandlingProps } from '../../../../types/meldekort/MeldekortBehandling';
+import React, { useEffect, useState } from 'react';
+import { formaterTidspunktKort } from '../../../../utils/date';
+import { MeldeperiodeKorrigering } from '../../../../types/meldekort/Meldeperiode';
+import { useMeldeperiodeKjede } from '../../MeldeperiodeKjedeContext';
+
+import style from './MeldekortAvsluttedeBehandlinger.module.css';
+import { AvsluttetMeldekortOppsummering } from './AvsluttetMeldekortOppsummering';
+
+export const MeldekortAvsluttedeBehandlinger = () => {
+    const [valgtIndex, setValgtIndex] = useState(0);
+
+    const { avbrutteMeldekortBehandlinger } = useMeldeperiodeKjede();
+
+    useEffect(() => {
+        setValgtIndex(0);
+    }, [avbrutteMeldekortBehandlinger]);
+
+    const valgtBehandling = avbrutteMeldekortBehandlinger.at(valgtIndex);
+
+    return (
+        <VStack gap={'5'}>
+            <HStack className={style.toppRad}>
+                <Select
+                    label={'Velg avsluttet behandling'}
+                    hideLabel={true}
+                    onChange={(event) => {
+                        setValgtIndex(Number(event.target.value));
+                    }}
+                    value={valgtIndex}
+                    size={'small'}
+                >
+                    {avbrutteMeldekortBehandlinger.map((mbeh, index) => {
+                        return (
+                            <option
+                                value={index}
+                                key={
+                                    erKorrigeringFraTidligerePeriode(mbeh)
+                                        ? mbeh.meldekortId
+                                        : mbeh.id
+                                }
+                            >
+                                {optionTekst(mbeh)}
+                            </option>
+                        );
+                    })}
+                </Select>
+            </HStack>
+            {valgtBehandling && (
+                <AvsluttetMeldekortOppsummering meldekortBehandling={valgtBehandling} />
+            )}
+        </VStack>
+    );
+};
+
+const erKorrigeringFraTidligerePeriode = (
+    behandlingEllerTidligereKorrigering: MeldekortBehandlingProps | MeldeperiodeKorrigering,
+): behandlingEllerTidligereKorrigering is MeldeperiodeKorrigering =>
+    !!(behandlingEllerTidligereKorrigering as MeldeperiodeKorrigering).meldekortId;
+
+const optionTekst = (mbeh: MeldekortBehandlingProps) => {
+    const tidspunkt = formaterTidspunktKort(mbeh.avbrutt!.avbruttTidspunkt);
+    return `Avsluttet ${tidspunkt}`;
+};

--- a/src/components/meldekort/MeldeperiodeKjedeContext.tsx
+++ b/src/components/meldekort/MeldeperiodeKjedeContext.tsx
@@ -16,6 +16,7 @@ export type MeldeperioderContextState = {
     alleMeldekortBehandlinger: MeldekortBehandlingProps[];
     sisteMeldekortBehandling?: MeldekortBehandlingProps;
     tidligereMeldekortBehandlinger: MeldekortBehandlingProps[];
+    avbrutteMeldekortBehandlinger: MeldekortBehandlingProps[];
 };
 
 export const MeldeperiodeKjedeContext = createContext<MeldeperioderContextState>(
@@ -33,7 +34,7 @@ export const MeldeperiodeKjedeProvider = ({
 }: Props) => {
     const [meldeperiodeKjede, setMeldeperiodeKjede] = useState(meldeperiodeKjedeInitial);
 
-    const { meldekortBehandlinger } = meldeperiodeKjede;
+    const { meldekortBehandlinger, avbrutteMeldekortBehandlinger } = meldeperiodeKjede;
 
     const sisteMeldeperiode = meldeperiodeKjede.meldeperioder.reduce((acc, meldeperiode) =>
         meldeperiode.versjon > acc.versjon ? meldeperiode : acc,
@@ -64,6 +65,7 @@ export const MeldeperiodeKjedeProvider = ({
                 alleMeldekortBehandlinger,
                 sisteMeldekortBehandling,
                 tidligereMeldekortBehandlinger,
+                avbrutteMeldekortBehandlinger,
             }}
         >
             {children}

--- a/src/components/oppsummeringer/oppsummeringAvAvbruttBehandling/OppsummeringAvAvbruttBehandling.tsx
+++ b/src/components/oppsummeringer/oppsummeringAvAvbruttBehandling/OppsummeringAvAvbruttBehandling.tsx
@@ -20,7 +20,7 @@ const AvbruttOppsummering = (props: {
         >
             <VStack gap="6">
                 <Heading size="medium" level="3">
-                    Behandling er Avsluttet
+                    Behandling er avsluttet
                 </Heading>
                 <HStack gap="6">
                     <OppsummeringsPar

--- a/src/components/saksoversikt/meldekort-oversikt/MeldekortBehandlingKnappForOversikt.tsx
+++ b/src/components/saksoversikt/meldekort-oversikt/MeldekortBehandlingKnappForOversikt.tsx
@@ -20,6 +20,7 @@ import { useTaMeldekortBehandling } from './useTaMeldekortBehandling';
 import { useLeggTilbakeMeldekortBehandling } from './useLeggTilbakeMeldekortBehandling';
 import { TriggerWithOptionsArgs } from 'swr/mutation';
 import { FetcherError } from '../../../utils/fetch/fetch';
+import AvsluttMeldekortBehandling from './avsluttMeldekortBehandling/AvsluttMeldekortBehandling';
 
 type Props = {
     meldekortBehandling: MeldekortBehandlingProps;
@@ -115,6 +116,11 @@ export const MeldekortBehandlingKnappForOversikt = ({
                     >
                         {'Legg tilbake'}
                     </Button>
+                    <AvsluttMeldekortBehandling
+                        sakId={sakId}
+                        meldekortBehandlingId={id}
+                        saksoversiktUrl={`/sak/${saksnummer}`}
+                    />
                 </VStack>
             );
 

--- a/src/components/saksoversikt/meldekort-oversikt/avsluttMeldekortBehandling/AvsluttMeldekortBehandling.module.css
+++ b/src/components/saksoversikt/meldekort-oversikt/avsluttMeldekortBehandling/AvsluttMeldekortBehandling.module.css
@@ -1,0 +1,11 @@
+.knapp {
+    min-width: 50%;
+}
+
+.varsel {
+    margin-bottom: 0.25rem;
+}
+
+.knappV2 {
+    margin-top: 0.25rem;
+}

--- a/src/components/saksoversikt/meldekort-oversikt/avsluttMeldekortBehandling/AvsluttMeldekortBehandling.tsx
+++ b/src/components/saksoversikt/meldekort-oversikt/avsluttMeldekortBehandling/AvsluttMeldekortBehandling.tsx
@@ -1,0 +1,127 @@
+import { BodyLong, Button, Heading, HStack, Modal, Textarea } from '@navikt/ds-react';
+import React, { useState } from 'react';
+import router from 'next/router';
+
+import style from './AvsluttMeldekortBehandling.module.css';
+
+import styles from '../../avsluttBehandling/AvsluttBehandling.module.css';
+import { TrashIcon } from '@navikt/aksel-icons';
+import { Controller, useForm } from 'react-hook-form';
+import { SakId } from '../../../../types/SakTypes';
+import {
+    MeldekortBehandlingId,
+    MeldekortBehandlingProps,
+} from '../../../../types/meldekort/MeldekortBehandling';
+import { useFetchJsonFraApi } from '../../../../utils/fetch/useFetchFraApi';
+
+const AvsluttMeldekortbehandlingModal = (props: {
+    sakId: SakId;
+    meldekortBehandlingId: MeldekortBehandlingId;
+    saksoversiktUrl: string;
+    åpen: boolean;
+    onClose: () => void;
+}) => {
+    const form = useForm<{ begrunnelse: string }>({ defaultValues: { begrunnelse: '' } });
+    const avsluttMeldekortBehandlingApi = useFetchJsonFraApi<
+        MeldekortBehandlingProps,
+        { begrunnelse: string }
+    >(`/sak/${props.sakId}/meldekort/${props.meldekortBehandlingId}/avbryt`, 'POST', {
+        onSuccess: () => {
+            router.push(props.saksoversiktUrl);
+        },
+    });
+
+    return (
+        <form
+            onSubmit={form.handleSubmit((values) => {
+                avsluttMeldekortBehandlingApi.trigger({
+                    begrunnelse: values.begrunnelse,
+                });
+            })}
+        >
+            <Modal
+                className={styles.modal}
+                width={700}
+                aria-label="Avslutt behandling"
+                open={props.åpen}
+                onClose={props.onClose}
+                size="small"
+            >
+                <Modal.Header className={styles.modalHeader}>
+                    <HStack>
+                        <TrashIcon title="Søppelbøtteikon" fontSize="1.5rem" />
+                        <Heading level="4" size="small">
+                            Avslutt behandling
+                        </Heading>
+                    </HStack>
+                </Modal.Header>
+                <Modal.Body className={styles.modalBody}>
+                    <BodyLong>
+                        Hvis du avslutter meldekortbehandlingen kan meldekortet ikke lenger
+                        behandles.
+                    </BodyLong>
+                    <Controller
+                        rules={{ required: 'Du må fylle ut en begrunnelse' }}
+                        control={form.control}
+                        render={({ field, fieldState }) => (
+                            <Textarea
+                                {...field}
+                                error={fieldState.error?.message}
+                                className={styles.textarea}
+                                label={'Hvorfor avsluttes behandlingen? (obligatorisk)'}
+                            />
+                        )}
+                        name={'begrunnelse'}
+                    />
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button
+                        variant="danger"
+                        size="small"
+                        loading={avsluttMeldekortBehandlingApi.isMutating}
+                        type="submit"
+                    >
+                        Avslutt behandling
+                    </Button>
+                    <Button variant="secondary" type="button" size="small" onClick={props.onClose}>
+                        Ikke avslutt behandling
+                    </Button>
+                </Modal.Footer>
+            </Modal>
+        </form>
+    );
+};
+
+const AvsluttMeldekortBehandling = (props: {
+    sakId: SakId;
+    meldekortBehandlingId: MeldekortBehandlingId;
+    saksoversiktUrl: string;
+}) => {
+    const [vilAvslutteBehandling, setVilAvslutteBehandling] = useState(false);
+
+    return (
+        <div>
+            {vilAvslutteBehandling && (
+                <AvsluttMeldekortbehandlingModal
+                    åpen={vilAvslutteBehandling}
+                    onClose={() => setVilAvslutteBehandling(false)}
+                    sakId={props.sakId}
+                    meldekortBehandlingId={props.meldekortBehandlingId}
+                    saksoversiktUrl={props.saksoversiktUrl}
+                />
+            )}
+            <Button
+                className={style.knapp}
+                size="small"
+                variant="danger"
+                onClick={() => {
+                    setVilAvslutteBehandling(true);
+                }}
+            >
+                Avslutt behandling
+            </Button>
+        </div>
+    );
+};
+
+export default AvsluttMeldekortBehandling;

--- a/src/types/meldekort/MeldekortBehandling.ts
+++ b/src/types/meldekort/MeldekortBehandling.ts
@@ -2,6 +2,7 @@ import { Attestering } from '../BehandlingTypes';
 import { MeldeperiodeId, MeldeperiodeKjedeId } from './Meldeperiode';
 import { Periode } from '../Periode';
 import { BrukersMeldekortId } from './BrukersMeldekort';
+import { Avbrutt } from '../Avbrutt';
 
 // Egentlig har denne samme prefix som BrukersMeldekortId (bare "meldekort_")
 // Typer den med en unik prefix for at typescript ikke skal se de som ekvivalente
@@ -15,6 +16,7 @@ export enum MeldekortBehandlingStatus {
     GODKJENT = 'GODKJENT',
     IKKE_RETT_TIL_TILTAKSPENGER = 'IKKE_RETT_TIL_TILTAKSPENGER',
     AUTOMATISK_BEHANDLET = 'AUTOMATISK_BEHANDLET',
+    AVBRUTT = 'AVBRUTT',
 }
 
 export enum MeldekortBehandlingDagStatus {
@@ -70,6 +72,7 @@ export type MeldekortBehandlingProps = {
     periode: Periode;
     dager: MeldekortDagProps[];
     beregning?: MeldekortBeregning;
+    avbrutt?: Avbrutt;
 };
 
 export type MeldekortDagProps = {

--- a/src/types/meldekort/Meldeperiode.ts
+++ b/src/types/meldekort/Meldeperiode.ts
@@ -24,6 +24,7 @@ export enum MeldeperiodeKjedeStatus {
     UNDER_BESLUTNING = 'UNDER_BESLUTNING',
     GODKJENT = 'GODKJENT',
     AUTOMATISK_BEHANDLET = 'AUTOMATISK_BEHANDLET',
+    AVBRUTT = 'AVBRUTT',
 }
 
 export type MeldeperiodeProps = {
@@ -47,6 +48,7 @@ export type MeldeperiodeKjedeProps = {
     meldekortBehandlinger: MeldekortBehandlingProps[];
     brukersMeldekort?: BrukersMeldekortProps;
     korrigeringFraTidligerePeriode?: MeldeperiodeKorrigering;
+    avbrutteMeldekortBehandlinger: MeldekortBehandlingProps[];
 };
 
 export type MeldeperiodeKorrigering = {

--- a/src/utils/tekstformateringUtils.ts
+++ b/src/utils/tekstformateringUtils.ts
@@ -55,6 +55,7 @@ export const finnMeldeperiodeKjedeStatusTekst: Record<MeldeperiodeKjedeStatus, s
     [MeldeperiodeKjedeStatus.UNDER_BESLUTNING]: 'Under beslutning',
     [MeldeperiodeKjedeStatus.GODKJENT]: 'Godkjent',
     [MeldeperiodeKjedeStatus.AUTOMATISK_BEHANDLET]: 'Automatisk behandlet',
+    [MeldeperiodeKjedeStatus.AVBRUTT]: 'Avsluttet',
 } as const;
 
 export const finnBehandlingstypeTekst: Record<Behandlingstype, string> = {


### PR DESCRIPTION
Lar saksbehandler få avbryte meldekortbehandlinger. Den må være tildelt saksbehandler, og må være i status "under behandling". Når behandlingen avsluttes forsvinner den fra saksoversikten, men den vises under "avsluttede behandlinger" inne på meldeperioden. 

https://trello.com/c/XU9ti14p/1461-mulig-for-saksbehandler-%C3%A5-avslutte-manuell-meldekortbehandling