### PR TITLE
1450 tekst om å informere bruker ved avslutning av behandling

### DIFF
--- a/src/components/saksoversikt/avsluttBehandling/AvsluttBehandling.tsx
+++ b/src/components/saksoversikt/avsluttBehandling/AvsluttBehandling.tsx
@@ -1,5 +1,14 @@
 import { TrashIcon } from '@navikt/aksel-icons';
-import { Modal, HStack, Heading, BodyLong, Textarea, Button, VStack } from '@navikt/ds-react';
+import {
+    Modal,
+    HStack,
+    Heading,
+    BodyLong,
+    Textarea,
+    Button,
+    VStack,
+    Alert,
+} from '@navikt/ds-react';
 import React from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import styles from './AvsluttBehandling.module.css';
@@ -150,6 +159,11 @@ const AvsluttBehandlingModal = (props: {
                         )}
                         name={'begrunnelse'}
                     />
+                    <Alert variant={'info'}>
+                        Bruker får ikke innsyn eller informasjon når behandlingen avsluttes i
+                        tiltakspenger-saksbehandling. Du må vurdere å informere bruker i Modia om
+                        hvorfor behandlingen er avsluttet, og hva vil det bety for bruker.
+                    </Alert>
                 </Modal.Body>
                 <Modal.Footer>
                     <Button

--- a/src/components/saksoversikt/avsluttBehandling/AvsluttBehandling.tsx
+++ b/src/components/saksoversikt/avsluttBehandling/AvsluttBehandling.tsx
@@ -162,7 +162,7 @@ const AvsluttBehandlingModal = (props: {
                     <Alert variant={'info'}>
                         Bruker får ikke innsyn eller informasjon når behandlingen avsluttes i
                         tiltakspenger-saksbehandling. Du må vurdere å informere bruker i Modia om
-                        hvorfor behandlingen er avsluttet, og hva vil det bety for bruker.
+                        hvorfor behandlingen er avsluttet, og hva det vil bety for bruker.
                     </Alert>
                 </Modal.Body>
                 <Modal.Footer>

--- a/src/components/saksoversikt/meldekort-oversikt/avsluttMeldekortBehandling/AvsluttMeldekortBehandling.tsx
+++ b/src/components/saksoversikt/meldekort-oversikt/avsluttMeldekortBehandling/AvsluttMeldekortBehandling.tsx
@@ -76,7 +76,7 @@ const AvsluttMeldekortbehandlingModal = (props: {
                     <Alert variant={'info'}>
                         Bruker får ikke innsyn eller informasjon når behandlingen avsluttes i
                         tiltakspenger-saksbehandling. Du må vurdere å informere bruker i Modia om
-                        hvorfor behandlingen er avsluttet, og hva vil det bety for bruker.
+                        hvorfor behandlingen er avsluttet, og hva det vil bety for bruker.
                     </Alert>
                 </Modal.Body>
                 <Modal.Footer>

--- a/src/components/saksoversikt/meldekort-oversikt/avsluttMeldekortBehandling/AvsluttMeldekortBehandling.tsx
+++ b/src/components/saksoversikt/meldekort-oversikt/avsluttMeldekortBehandling/AvsluttMeldekortBehandling.tsx
@@ -1,4 +1,4 @@
-import { BodyLong, Button, Heading, HStack, Modal, Textarea } from '@navikt/ds-react';
+import { Alert, BodyLong, Button, Heading, HStack, Modal, Textarea } from '@navikt/ds-react';
 import React, { useState } from 'react';
 import router from 'next/router';
 
@@ -73,6 +73,11 @@ const AvsluttMeldekortbehandlingModal = (props: {
                         )}
                         name={'begrunnelse'}
                     />
+                    <Alert variant={'info'}>
+                        Bruker får ikke innsyn eller informasjon når behandlingen avsluttes i
+                        tiltakspenger-saksbehandling. Du må vurdere å informere bruker i Modia om
+                        hvorfor behandlingen er avsluttet, og hva vil det bety for bruker.
+                    </Alert>
                 </Modal.Body>
                 <Modal.Footer>
                     <Button


### PR DESCRIPTION
https://trello.com/c/ApKH2atQ/1450-hvordan-ivaretar-vi-brukers-rett-til-innsyn-hvis-en-s%C3%B8knad-og-en-manuell-meldekort-avsluttes