### PR TITLE
1439 tilbakeknapp for avsluttede behandlinger og avbrutt-status

### DIFF
--- a/src/pages/sak/[saksnummer]/avbrutt/[id]/index.tsx
+++ b/src/pages/sak/[saksnummer]/avbrutt/[id]/index.tsx
@@ -33,7 +33,11 @@ const AvbruttPage = (props: Props) => {
 
     return (
         <SakProvider sak={props.sak}>
-            <PersonaliaHeader sakId={props.sak.sakId} saksnummer={props.sak.saksnummer} />
+            <PersonaliaHeader
+                sakId={props.sak.sakId}
+                saksnummer={props.sak.saksnummer}
+                visTilbakeKnapp={true}
+            />
             <SideBarMain
                 sidebar={
                     <OppsummeringAvSøknad

--- a/src/types/BehandlingTypes.ts
+++ b/src/types/BehandlingTypes.ts
@@ -73,6 +73,7 @@ export enum BehandlingStatus {
     KLAR_TIL_BESLUTNING = 'KLAR_TIL_BESLUTNING',
     UNDER_BESLUTNING = 'UNDER_BESLUTNING',
     VEDTATT = 'VEDTATT',
+    AVBRUTT = 'AVBRUTT',
 }
 
 export type Attestering = {

--- a/src/utils/tekstformateringUtils.ts
+++ b/src/utils/tekstformateringUtils.ts
@@ -20,6 +20,8 @@ export const finnBehandlingStatusTekst = (status: BehandlingStatus, underkjent: 
             return underkjent ? 'Underkjent' : 'Under behandling';
         case BehandlingStatus.UNDER_BESLUTNING:
             return 'Under beslutning';
+        case BehandlingStatus.AVBRUTT:
+            return 'Avsluttet';
     }
 };
 


### PR DESCRIPTION
https://trello.com/c/Jq9aYD5I/1439-bug-knapp-tilbake-til-saksoversikten-er-forsvunnet-n%C3%A5r-jeg-har-tatt-opp-en-avsluttet-s%C3%B8knad