### PR TITLE
legger til behandlingsutfall stans

### DIFF
--- a/src/components/behandling/revurdering/stans/3-brev/forhåndsvisning/VedtaksbrevForhåndsvisning.tsx
+++ b/src/components/behandling/revurdering/stans/3-brev/forhåndsvisning/VedtaksbrevForhåndsvisning.tsx
@@ -7,6 +7,7 @@ import { useRevurderingVedtak } from '../../../RevurderingVedtakContext';
 import { useRevurderingBehandling } from '../../../../BehandlingContext';
 import React from 'react';
 import { revurderingStansValidering } from '../../../revurderingStansValidering';
+import { Behandlingsutfall } from '../../../../../../types/BehandlingTypes';
 
 export const VedtaksbrevForhåndsvisning = () => {
     const { behandling } = useRevurderingBehandling();
@@ -33,6 +34,7 @@ export const VedtaksbrevForhåndsvisning = () => {
                             fritekst: revurderingVedtak.brevtekstRef.current?.value ?? '',
                             stansDato: revurderingVedtak.stansdato,
                             valgteHjemler: revurderingVedtak.valgtHjemmelHarIkkeRettighet,
+                            utfall: behandling.utfall ?? Behandlingsutfall.STANS,
                         }).then((blob) => {
                             if (blob) {
                                 window.open(URL.createObjectURL(blob));

--- a/src/components/behandling/revurdering/stans/3-brev/forhåndsvisning/useHentVedtaksbrevForhåndsvisning.ts
+++ b/src/components/behandling/revurdering/stans/3-brev/forhåndsvisning/useHentVedtaksbrevForhåndsvisning.ts
@@ -1,10 +1,11 @@
-import { BehandlingData } from '../../../../../../types/BehandlingTypes';
+import { BehandlingData, Behandlingsutfall } from '../../../../../../types/BehandlingTypes';
 import { useFetchBlobFraApi } from '../../../../../../utils/fetch/useFetchFraApi';
 
 type BrevForhåndsvisningDTO = {
     fritekst: string;
     stansDato: string;
     valgteHjemler: string[];
+    utfall: Behandlingsutfall;
 };
 
 export const useHentVedtaksbrevForhåndsvisning = (behandling: BehandlingData) => {

--- a/src/types/BehandlingTypes.ts
+++ b/src/types/BehandlingTypes.ts
@@ -127,4 +127,5 @@ export enum Avslagsgrunn {
 export enum Behandlingsutfall {
     AVSLAG = 'AVSLAG',
     INNVILGELSE = 'INNVILGELSE',
+    STANS = 'STANS',
 }

--- a/src/utils/tekstformateringUtils.ts
+++ b/src/utils/tekstformateringUtils.ts
@@ -69,6 +69,7 @@ export const finnBehandlingstypeTekst: Record<Behandlingstype, string> = {
 export const behandlingsutfallTilTekst: Record<Behandlingsutfall, string> = {
     [Behandlingsutfall.AVSLAG]: 'Avslag',
     [Behandlingsutfall.INNVILGELSE]: 'Innvilgelse',
+    [Behandlingsutfall.STANS]: 'Stans',
 } as const;
 
 export const meldekortUtbetalingstatusTekst: Record<Utbetalingsstatus, string> = {


### PR DESCRIPTION
Behandlingsutfall STANS manglet, og når vi ikke sendte med behandlingsutfall ved forhåndsvisning av revurdering feilet det fordi feltet er påkrevd av apiet i backend. 