### PR TITLE
1402 disabler forhåndsvis-knappen hvis skjemaet inneholder feil

### DIFF
--- a/src/components/behandling/førstegangsbehandling/6-brev/forhåndsvisning/VedtaksbrevForhåndsvisning.tsx
+++ b/src/components/behandling/førstegangsbehandling/6-brev/forhåndsvisning/VedtaksbrevForhåndsvisning.tsx
@@ -6,6 +6,7 @@ import { useFørstegangsbehandling } from '../../../BehandlingContext';
 
 import style from './VedtaksbrevForhåndsvisning.module.css';
 import { Behandlingsutfall } from '../../../../../types/BehandlingTypes';
+import { førstegangsVedtakValidering } from '../../førstegangsVedtakValidering';
 
 export const VedtaksbrevForhåndsvisning = () => {
     const { behandling } = useFørstegangsbehandling();
@@ -13,6 +14,9 @@ export const VedtaksbrevForhåndsvisning = () => {
 
     const { hentForhåndsvisning, forhåndsvisningLaster, forhåndsvisningError } =
         useHentVedtaksbrevForhåndsvisning(behandling);
+
+    const valideringResultat = førstegangsVedtakValidering(behandling, vedtak);
+    const harValideringsfeil = valideringResultat.errors.length > 0;
 
     return (
         <>
@@ -22,6 +26,7 @@ export const VedtaksbrevForhåndsvisning = () => {
                 variant="secondary"
                 icon={<EnvelopeOpenIcon />}
                 className={style.knapp}
+                disabled={harValideringsfeil}
                 loading={forhåndsvisningLaster}
                 onClick={async () => {
                     //Backend vil ignorere perioden dersom vedtaket er avslag, og hvis tilstanden er tilBeslutter (senere enn under behandling)

--- a/src/components/behandling/førstegangsbehandling/førstegangsVedtakValidering.ts
+++ b/src/components/behandling/førstegangsbehandling/førstegangsVedtakValidering.ts
@@ -24,6 +24,10 @@ export const førstegangsVedtakValidering = (
         errors.push('Behandlingsutfall for vilkårsvurdering mangler');
     }
 
+    if (behandlingsperiode.fraOgMed > behandlingsperiode.tilOgMed) {
+        errors.push('Til og med-dato må være etter fra og med-dato');
+    }
+
     if (tiltaksperiode.fraOgMed > behandlingsperiode.fraOgMed) {
         errors.push('Behandlingsperioden starter før tiltaksperioden');
     }

--- a/src/components/behandling/revurdering/stans/3-brev/forhåndsvisning/VedtaksbrevForhåndsvisning.tsx
+++ b/src/components/behandling/revurdering/stans/3-brev/forhåndsvisning/VedtaksbrevForhåndsvisning.tsx
@@ -18,6 +18,7 @@ export const VedtaksbrevForhåndsvisning = () => {
 
     const [showValidationError, setShowValidationError] = React.useState(false);
     const validering = revurderingStansValidering(revurderingVedtak);
+    const harValideringsfeil = validering.errors.length > 0;
 
     return (
         <>
@@ -27,6 +28,7 @@ export const VedtaksbrevForhåndsvisning = () => {
                 variant="secondary"
                 icon={<EnvelopeOpenIcon />}
                 className={style.knapp}
+                disabled={harValideringsfeil}
                 loading={forhåndsvisningLaster}
                 onClick={async () => {
                     if (validering.errors.length === 0) {


### PR DESCRIPTION
https://trello.com/c/5nleiYmo/1402-bedre-feilmelding-n%C3%A5r-forh%C3%A5ndsvisning-av-brev-feiler

La også inn en validering av at fom-dato er før tom-dato siden det manglet. 